### PR TITLE
fix: space wasn't being emitted in apps post 1.9.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,10 +98,6 @@ function neatInput (opts) {
         input.emit('right')
         return true
 
-      case 'space':
-        input.emit('space')
-        return true
-
       case 'backspace':
         rawLine = rawLine.slice(0, Math.max(input.cursor - 1, 0)) + rawLine.slice(input.cursor)
         moveCursorLeft()
@@ -125,6 +121,10 @@ function neatInput (opts) {
         if (ch === '\n' || ch === '\r') {
           onenter(rawLine)
           return false // onenter emits update
+        }
+
+        if (ch === ' ') {
+          input.emit('space')
         }
 
         if (ch) {


### PR DESCRIPTION
using spaces had [broken](https://github.com/cabal-club/cabal/issues/104) in cabal and nobody knew why

i figured out why and tried to patch it, let me know if this breaks your original use case @watson! 
i kept the emitted event, but now space is also added to the `rawLine` - which i would consider to be the intended behaviour