### PR TITLE
emit keypress before emitting update

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,8 +178,8 @@ function neatInput (opts) {
   }
 
   function onkeypress (ch, key) {
-    if (handle(ch, key)) input.emit('update')
     input.emit('keypress', ch, key)
+    if (handle(ch, key)) input.emit('update')
   }
 
   function hideCursor () {


### PR DESCRIPTION
i'm tinkering with a small toy game that uses neat-input and ran into an issue with keypresses & updating.

this pr emits keypresses first _then_ emits the update event. this allows keypresses to be registered/acted on before the update event fires (i.e. before rerendering the cli view).

all tests pass
``` 
1..74
# tests 74
# pass  74
```